### PR TITLE
authenticated? refers to a request, not a session

### DIFF
--- a/src/clojure/buddy/auth.clj
+++ b/src/clojure/buddy/auth.clj
@@ -21,7 +21,7 @@
   "Test if a current request is
   authenticated or not."
   [request]
-  (boolean (:identity request)))
+  (boolean (:identity (:session request)))
 
 (defn throw-unauthorized
   ([] (throw-unauthorized {}))


### PR DESCRIPTION
**The problem**
In the example (https://github.com/funcool/buddy-auth/blob/master/examples/session/src/authexample/web.clj#L34) function `authenticated?` takes request as an argument, but searches for `:identity` in the passed argument as if it was session

 **The solution**
We could pass `(:session request)` to `authenticated?` but passing whole request makes sense because this function theoretically could refer to other request attributes, so I changed the implementation of the function, and left the mentioned example intact. 
