### PR TITLE
Match access rules against HTTP methods

### DIFF
--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -353,6 +353,16 @@ link:https://github.com/weavejester/clout[clout] url matching syntax or regular 
   :handler user-access}
 ----
 
+An access rule can also match against certain HTTP methods, by using the *:request-method* option. *:request-method* can be a keyword or a set of keywords.
+
+.An example of an access rule that matches only GET requests.
+[source, clojure]
+----
+[{:uri "/foo"
+  :handler user-access
+  :request-method :get}
+----
+
 === Rules Handlers
 
 The rule handler is a plain function that accepts a

--- a/test/buddy/auth/accessrules_tests.clj
+++ b/test/buddy/auth/accessrules_tests.clj
@@ -160,3 +160,65 @@
     (is (thrown? Exception (handler3 {:uri "/path4"}))))
 )
 
+(defn method-handler [type type-param allowed]
+  (wrap-access-rules
+   test-handler
+   {:rules [{type type-param
+             :handler ok
+             :request-method allowed}]
+    :policy :reject}))
+
+(deftest wrap-access-rules-method-test
+  (let [allowed {:uri "/comments/1" :request-method :get}
+        forbidden (assoc allowed :request-method :delete)]
+
+    (testing "access rule pattern"
+      (let [method-handler (partial method-handler :pattern #"/comments/\d+")]
+
+        (testing "with keyword as allowed method"
+          (let [handler (method-handler :get)]
+            (is (= (:body (handler allowed)) allowed))
+            (is (thrown? Exception (handler forbidden)))))
+
+        (testing "with set of keywords as allowed method"
+          (let [handler (method-handler #{:get})]
+            (is (= (:body (handler allowed)) allowed))
+            (is (thrown? Exception (handler forbidden)))))
+
+        (testing "with nil as allowed request method"
+          (let [handler (method-handler nil)]
+            (is (= (:body (handler allowed)) allowed))))))
+
+    (testing "access rule uri"
+      (let [method-handler (partial method-handler :uri "/comments/:id")]
+
+        (testing "with keyword as allowed method"
+          (let [handler (method-handler :get)]
+            (is (= (:body (handler allowed)) allowed))
+            (is (thrown? Exception (handler forbidden)))))
+
+        (testing "with set of keywords as allowed method"
+          (let [handler (method-handler #{:get})]
+            (is (= (:body (handler allowed)) allowed))
+            (is (thrown? Exception (handler forbidden)))))
+
+        (testing "with nil as allowed request method"
+          (let [handler (method-handler nil)]
+            (is (= (:body (handler allowed)) allowed))))))
+
+    (testing "access rule uris"
+      (let [method-handler (partial method-handler :uris ["/comments/:id"])]
+
+        (testing "with keyword as allowed method"
+          (let [handler (method-handler :get)]
+            (is (= (:body (handler allowed)) allowed))
+            (is (thrown? Exception (handler forbidden)))))
+
+        (testing "with set of keywords as allowed method"
+          (let [handler (method-handler #{:get})]
+            (is (= (:body (handler allowed)) allowed))
+            (is (thrown? Exception (handler forbidden)))))
+
+        (testing "with nil as allowed request method"
+          (let [handler (method-handler nil)]
+            (is (= (:body (handler allowed)) allowed))))))))


### PR DESCRIPTION
This commit adds support to match access rules against the HTTP method
of an request. Access rules take an optional `:request-method`
parameter. `:request-method` can be either a keyword, or a set of
keywords.
