### PR TITLE
Return the last failure of an or handler, not the first

### DIFF
--- a/src/clojure/buddy/auth/accessrules.clj
+++ b/src/clojure/buddy/auth/accessrules.clj
@@ -140,7 +140,7 @@
                        accepts (filter success? evals)]
                    (if (seq accepts)
                      (first accepts)
-                     (first evals))))
+                     (last evals))))
 
                (:and form)
                (fn [req]

--- a/test/buddy/auth/accessrules_tests.clj
+++ b/test/buddy/auth/accessrules_tests.clj
@@ -44,6 +44,11 @@
     (let [rule (#'acr/compile-rule-handler {:or [fail2 ok2]})
           result (rule 1)]
       (is (= true result))))
+
+  (testing "compile access rules 8"
+    (let [rule (#'acr/compile-rule-handler {:or [fail2 fail]})
+          result (rule 1)]
+      (is (= (error 1) result))))
 )
 
 (defn test-handler


### PR DESCRIPTION
This commit changes the `compile-rule-handler` to return the last
failure of an `or` handler. This is consistent with the behaviour of
Clojure's `or` macro.

```
(or nil false)
;=> false
```

```
(or false nil)
;=> nil
```
