### PR TITLE
Change access rule pattern matching to always match against the URI

### DIFF
--- a/src/buddy/auth/accessrules.clj
+++ b/src/buddy/auth/accessrules.clj
@@ -190,8 +190,9 @@
   The clout library (https://github.com/weavejester/clout)
   for matching the `:uri`.
 
-  It also has support for more advanced matching using
-  plain regular expressions:
+  It also has support for more advanced matching using plain
+  regular expressions, which are matched against the full
+  request uri:
 
       [{:pattern #\"^/foo$\"
         :handler user-access}
@@ -225,8 +226,7 @@
                   (:pattern accessrule)
                   (fn [request]
                     (let [pattern (:pattern accessrule)
-                          uri (or (:path-info request)
-                                  (:uri request))]
+                          uri (:uri request)]
                       (when (and (matches-request-method request request-method)
                                  (seq (re-matches pattern uri)))
                         {})))


### PR DESCRIPTION
Previously, the access-rule pattern matcher fn mimicked compojure route matching, preferring `:path-info` over the `:uri` if the request path-info was non-nil. However, since the path-info would be the portion of the URI after the matched route, its counter productive to matching access-rules. 

For example:

``` clojure
;; using compojure to demonstrate, given its implementation of context
(context "/account/:id" [id]
  (GET "/show" _ (show-account id)))

;; A request to /account/1/show would come through as:
{:context "/account/"
 :path-info "/show"
 :uri "/account/1/show"}

;; A logical access rule pattern would be
(def access-rules 
  {:rules [:pattern #"^/account/.*$"
           :handler authenticated-user?]})
```

However, given the previous implementation, the pattern would not match, because the match target for the above request would be `"/show"`, not `"/account/1/show"`.
