### PR TITLE
Fixes #31 NPE

### DIFF
--- a/src/buddy/auth/middleware.clj
+++ b/src/buddy/auth/middleware.clj
@@ -31,14 +31,11 @@
   (fn [request]
     (let [authentication (loop [[backend & backends] backends]
                            (when backend
-                             (let [request (assoc request :auth-backend backend)
-                                   authentication (some->> request
-                                                           (proto/parse backend)
-                                                           (proto/authenticate backend request))]
-                               (if (or (empty? backends)
-                                       (:identity authentication))
-                                 authentication
-                                 (recur backends)))))]
+                             (let [request (assoc request :auth-backend backend)]
+                               (or (some->> request
+                                            (proto/parse backend)
+                                            (proto/authenticate backend request))
+                                   (recur backends)))))]
       (if (http/response? authentication)
         authentication
         (handler (or authentication request))))))

--- a/src/buddy/auth/middleware.clj
+++ b/src/buddy/auth/middleware.clj
@@ -29,20 +29,19 @@
   chance to authenticate the request."
   [handler & backends]
   (fn [request]
-    (if (empty? backends)
-      (handler request)
-      (loop [[current & pending] backends]
-        (let [last? (empty? pending)
-              request (assoc request :auth-backend current)
-              rsq (proto/parse current request)]
-          (if (and (nil? rsq) last?)
-            (handler request)
-            (let [rsq (proto/authenticate current request rsq)]
-              (if (and (http/response? rsq) last?)
-                rsq
-                (if (or (:identity rsq) last?)
-                  (handler (or rsq request))
-                  (recur pending))))))))))
+    (let [authentication (loop [[backend & backends] backends]
+                           (when backend
+                             (let [request (assoc request :auth-backend backend)
+                                   authentication (some->> request
+                                                           (proto/parse backend)
+                                                           (proto/authenticate backend request))]
+                               (if (or (empty? backends)
+                                       (:identity authentication))
+                                 authentication
+                                 (recur backends)))))]
+      (if (http/response? authentication)
+        authentication
+        (handler (or authentication request))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Authorization


### PR DESCRIPTION
Have a look at this. 

It's still odd logic, in that a backend may return a response agreeing to `http/response?`, but this is skipped over if there are more backends to try. 

I would think that if a backend authenticate returns either a request with identity in, or is a response, then processing of backends should stop there.

If you can agree, I can modify this PR.
