### PR TITLE
Support Pedestals interceptors

### DIFF
--- a/src/buddy/auth/middleware.clj
+++ b/src/buddy/auth/middleware.clj
@@ -40,7 +40,7 @@
   handler. When multiple `backends` are given each of them gets a
   chance to authenticate the request."
   [handler & backends]
-  (fn [request] (handler (authentication-request request [backends]))))
+  (fn [request] (handler (apply authentication-request request backends))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Authorization

--- a/src/buddy/auth/middleware.clj
+++ b/src/buddy/auth/middleware.clj
@@ -22,20 +22,25 @@
 ;; Authentication
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defn authentication-request
+  "Updates request with authentication. If multiple `backends` are given
+  each of them gets a chance to authenticate the request."
+  [request & backends]
+  (let [authdata (loop [[backend & backends] backends]
+                   (when backend
+                     (let [request (assoc request :auth-backend backend)]
+                       (or (some->> request
+                                    (proto/-parse backend)
+                                    (proto/-authenticate backend request))
+                           (recur backends)))))]
+    (assoc request :identity authdata)))
+
 (defn wrap-authentication
   "Ring middleware that enables authentication for your ring
   handler. When multiple `backends` are given each of them gets a
   chance to authenticate the request."
   [handler & backends]
-  (fn [request]
-    (let [authdata (loop [[backend & backends] backends]
-                     (when backend
-                       (let [request (assoc request :auth-backend backend)]
-                         (or (some->> request
-                                      (proto/-parse backend)
-                                      (proto/-authenticate backend request))
-                             (recur backends)))))]
-      (handler (assoc request :identity authdata)))))
+  (fn [request] (handler (authentication-request request [backends]))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Authorization
@@ -52,6 +57,30 @@
     (-handle-unauthorized [_ request errordata]
       (callable request errordata))))
 
+(defn authorization-error
+  "Handles authorization errors.
+
+  The `backend` parameter should be a plain function
+  that accepts two parameters: request and errordata hashmap,
+  or an instance that satisfies IAuthorization protocol."
+  [request e backend]
+  (let [backend (cond
+                  (fn? backend)
+                  (fn->authorization-backend backend)
+
+                  (satisfies? proto/IAuthorization backend)
+                  backend)]
+    (if (instance? clojure.lang.ExceptionInfo e)
+      (let [data (ex-data e)]
+        (if (= (:buddy.auth/type data) :buddy.auth/unauthorized)
+          (->> (:buddy.auth/payload data)
+               (proto/-handle-unauthorized backend request))
+          (throw e)))
+      (if (satisfies? proto/IAuthorizationdError e)
+        (->> (proto/-get-error-data e)
+             (proto/-handle-unauthorized backend request))
+        (throw e)))))
+
 (defn wrap-authorization
   "Ring middleware that enables authorization
   workflow for your ring handler.
@@ -61,23 +90,7 @@
   hashmap, or an instance that satisfies IAuthorization
   protocol."
   [handler backend]
-  (let [backend (cond
-                  (fn? backend)
-                  (fn->authorization-backend backend)
-
-                  (satisfies? proto/IAuthorization backend)
-                  backend)]
-    (fn [request]
-      (try
-        (handler request)
-        (catch clojure.lang.ExceptionInfo e
-          (let [data (ex-data e)]
-            (if (= (:buddy.auth/type data) :buddy.auth/unauthorized)
-              (->> (:buddy.auth/payload data)
-                   (proto/-handle-unauthorized backend request))
-              (throw e))))
-        (catch Exception e
-          (if (satisfies? proto/IAuthorizationdError e)
-            (->> (proto/-get-error-data e)
-                 (proto/-handle-unauthorized backend request))
-            (throw e)))))))
+  (fn [request]
+    (try (handler request)
+         (catch Exception e
+           (authorization-error request e backend)))))


### PR DESCRIPTION
wrap-authentication and wrap-authorization have each been split to two
functions.

wrap-authentication
wrap-authorization:
For ring; just calls the respective function and wraps it with (handler)

authentication-request for :enter intererceptor stage
authorization-error for :error intereceptor stage
