### PR TITLE
Fix JWS example.

### DIFF
--- a/examples/jws/src/authexample/web.clj
+++ b/examples/jws/src/authexample/web.clj
@@ -9,7 +9,7 @@
             [ring.middleware.json :refer [wrap-json-response wrap-json-body]]
             [ring.adapter.jetty :as jetty]
             [clj-time.core :as time]
-            [buddy.sign.jws :as jws]
+            [buddy.sign.jwt :as jwt]
             [buddy.auth :refer [authenticated? throw-unauthorized]]
             [buddy.auth.backends.token :refer [jws-backend]]
             [buddy.auth.middleware :refer [wrap-authentication wrap-authorization]])
@@ -60,7 +60,7 @@
     (if valid?
       (let [claims {:user (keyword username)
                     :exp (time/plus (time/now) (time/seconds 3600))}
-            token (jws/sign claims secret {:alg :hs512})]
+            token (jwt/sign claims secret {:alg :hs512})]
         (ok {:token token}))
       (bad-request {:message "wrong auth data"}))))
 


### PR DESCRIPTION
The example app for Signed JWT auth is failing. It looks like it is calling the wrong "sign" function in the login.
