### PR TITLE
Add support for custom authfn for all auth.backends

### DIFF
--- a/src/buddy/auth/backends/session.clj
+++ b/src/buddy/auth/backends/session.clj
@@ -20,13 +20,13 @@
             [clojure.string :refer [split]]))
 
 (defn session-backend
-  [& [{:keys [unauthorized-handler]}]]
+  [& [{:keys [unauthorized-handler authfn] :or {authfn identity}}]]
   (reify
     proto/IAuthentication
     (-parse [_ request]
       (:identity (:session request)))
     (-authenticate [_ request data]
-      data)
+      (authfn data))
 
     proto/IAuthorization
     (-handle-unauthorized [_ request metadata]

--- a/test/buddy/auth/backends/session_tests.clj
+++ b/test/buddy/auth/backends/session_tests.clj
@@ -10,6 +10,7 @@
   ([id] {:session {:identity {:userid 1}}}))
 
 (def backend (backends/session))
+(def backend-with-authfn (backends/session {:authfn (constantly ::authorized)}))
 
 (deftest session-backend-test
   (testing "Simple backend authentication 01"
@@ -48,4 +49,10 @@
                       (wrap-authentication backend))
           request (make-request 1)
           response (handler request)]
-      (is (= (:status response) 403)))))
+      (is (= (:status response) 403))))
+
+  (testing "Uses custom authfn when provided"
+    (let [handler (wrap-authentication identity backend-with-authfn)
+          request (make-request 1)
+          response (handler request)]
+      (is (= ::authorized (:identity response))))))


### PR DESCRIPTION
Adds an `authfn` for session, jwe, jws backends.

This transformation function allows for better composition backends by allowing developers to unify the shape of the data passed to the next handler in the middleware chain.

Fixes #61 