### PR TITLE
http headers may be keywords as well as strings

### DIFF
--- a/src/buddy/auth/http.clj
+++ b/src/buddy/auth/http.clj
@@ -53,7 +53,7 @@
   "Looks up a header in a headers map case insensitively,
   returning the header map entry, or nil if not present."
   [headers ^String header-name]
-  (first (filter #(.equalsIgnoreCase header-name (key %)) headers)))
+  (first (filter #(.equalsIgnoreCase header-name (name (key %))) headers)))
 
 (extend-protocol IRequest
   clojure.lang.IPersistentMap


### PR DESCRIPTION
Hi,

Although the [ring spec](https://github.com/ring-clojure/ring/blob/master/SPEC) says headers should be strings, it is common to coerce header keys to keywords which makes buddy's header parsing blow up.

This change fixes that and allows it to work with keywordised header maps.

Thanks