### PR TITLE
Set version 2.0.0. Update dependencies. Update changelog

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -1,5 +1,14 @@
 = Changelog
 
+== Version 2.0.0
+
+Date: 2017-08-10
+
+- Allow keywords for HTTP headers as well as strings
+- Update to use Clojure 1.9.0-alpha17
+- Update buddy-sign to 2.0.0 (implicit breaking change no longer handling `iat` validation)
+- Update cuerdas to 2.0.2
+
 == Version 1.4.1
 
 Date: 2017-01-29

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # buddy-auth
 
 [![Travis Badge](https://img.shields.io/travis/funcool/buddy-auth.svg?style=flat)](https://travis-ci.org/funcool/buddy-auth "Travis Badge")
+[![Dependencies Status](http://jarkeeper.com/funcool/buddy-auth/status.svg)](http://jarkeeper.com/funcool/buddy-auth)
 
 *buddy-auth* module is dedicated to provide **Authentication** and **Authorization** facilities
 for ring and ring based web applications.

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -1,6 +1,6 @@
 = buddy-auth - Auth/Authz facilities for ring based apps.
 Andrey Antukh, <niwi@niwi.nz>
-1.4.1
+2.0.0
 :toc: left
 :!numbered:
 :source-highlighter: pygments
@@ -28,7 +28,7 @@ your *_project.clj_* dependency vector:
 
 [source,clojure]
 ----
-[buddy/buddy-auth "1.4.1"]
+[buddy/buddy-auth "2.0.0"]
 ----
 
 This package is intended to be used with *jdk7* or *jdk8*.

--- a/profiles.clj
+++ b/profiles.clj
@@ -12,9 +12,9 @@
  :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
 
  :examples
- {:dependencies [[ring "1.4.0"]
+ {:dependencies [[ring "1.6.2"]
                  [ring/ring-json "0.4.0"]
-                 [compojure "1.4.0"]]}
+                 [compojure "1.6.0"]]}
 
  :session-example
  [:examples

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject buddy/buddy-auth "1.4.1"
+(defproject buddy/buddy-auth "2.0.0"
   :description "Authentication and Authorization facilities for ring based web applications."
   :url "https://github.com/funcool/buddy-auth"
   :license {:name "Apache 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha14" :scope "provided"]
-                 [buddy/buddy-sign "1.4.0"]
-                 [funcool/cuerdas "2.0.2"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha17" :scope "provided"]
+                 [buddy/buddy-sign "2.0.0"]
+                 [funcool/cuerdas "2.0.3"]
                  [clout "2.1.2"]]
   :source-paths ["src"]
   :test-paths ["test"]


### PR DESCRIPTION
Also added dependency status link in README.

Should version move to `2.0.0` given the implicit breaking change via buddy-sign (no longer validating `iat` against "now")?