### PR TITLE
Update home function in web.clj

### DIFF
--- a/examples/session/src/authexample/web.clj
+++ b/examples/session/src/authexample/web.clj
@@ -28,7 +28,7 @@
   (if-not (authenticated? request)
     (throw-unauthorized)
     (let [content (slurp (io/resource "index.html"))]
-      (response content))))
+      (render content request))))
 
 ;; Login page controller
 ;; It returns a login page on get requests.


### PR DESCRIPTION
(response content) from home function causes the browser to download the index.html instead of rendering it.

Change to (render content request) in order to properly send the page to client.