### PR TITLE
Fix CI config and add JDK 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: clojure
-lein: lein2
+lein: lein
 
 script:
-  - lein2 test
+  - lein test
 
 jdk:
   - oraclejdk8
   - openjdk7
   - oraclejdk7
+  - oraclejdk9


### PR DESCRIPTION
* Fix CI config and add JDK 9.
* Verified with https://travis-ci.org/tirkarthi/buddy-auth/builds/332260019

Many of the repos have `lein2` that cause build failure. Will raise fixes for the same.

https://github.com/search?q=org%3Afuncool+lein2&type=Code&utf8=%E2%9C%93