### PR TITLE
Support async middleware

### DIFF
--- a/src/buddy/auth/fnutils.clj
+++ b/src/buddy/auth/fnutils.clj
@@ -1,0 +1,48 @@
+;; Copyright 2013-2016 Andrey Antukh <niwi@niwi.nz>
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License")
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns buddy.auth.fnutils
+  "Utility to reuse 1-arity handlers into 3-arity handlers for async support")
+
+
+(defn sync-async-handler-fn
+  "Receives a 1-arity ring handler function and returns a multiple arity ring 
+  handler function."
+  [handler]
+  (fn [request] 
+    (handler request))
+  (fn [request respond raise] 
+    (try (respond (handler request))
+      (catch Exception e
+        (raise e)))))
+
+
+(defmacro fn->multi 
+  "Takes an anonymous `(fn [request] ...)` declaration of 1-arity and converts it to a multiple arity `fn`,
+   supporting both sync and async handler styles."
+  [req body]
+  {:pre [(= 1 (count req))]}
+  `(fn ([~@req] ~body)
+       ([~@req respond# raise#]
+         (try 
+           (respond# ~body)
+           (catch Exception e#
+             (raise# e#))))))
+
+
+#_(def f (n->multi [r] (/ 1 r)))
+
+#_(f 1 (partial println "respond")  (partial println "raise"))
+#_(clojure.walk/macroexpand-all  '(defn wrap-auth [handler] (n->multi [request] (handler request))))
+#_(clojure.pprint/pprint (macroexpand-1  '(fnhandler [request] (+ 1 request))))

--- a/src/buddy/auth/fnutils.clj
+++ b/src/buddy/auth/fnutils.clj
@@ -15,22 +15,12 @@
 (ns buddy.auth.fnutils
   "Utility to reuse 1-arity handlers into 3-arity handlers for async support")
 
-
-(defn sync-async-handler-fn
-  "Receives a 1-arity ring handler function and returns a multiple arity ring 
-  handler function."
-  [handler]
-  (fn [request] 
-    (handler request))
-  (fn [request respond raise] 
-    (try (respond (handler request))
-      (catch Exception e
-        (raise e)))))
-
-
 (defmacro fn->multi 
-  "Takes an anonymous `(fn [request] ...)` declaration of 1-arity and converts it to a multiple arity `fn`,
-   supporting both sync and async handler styles."
+  "Replaces an anonymous `(fn [request] ...)` declaration of arity-1 and converts it to a multiple arity `fn`
+   (arity-1 and arity-3), supporting both sync and async handler styles.
+  
+  Instead of declaring an anonymous function `(fn [handler] ...)`, replace the `fn` with the macro:
+  `(fn->multi [handler] ...)`"
   [req body]
   {:pre [(= 1 (count req))]}
   `(fn ([~@req] ~body)
@@ -39,10 +29,3 @@
            (respond# ~body)
            (catch Exception e#
              (raise# e#))))))
-
-
-#_(def f (n->multi [r] (/ 1 r)))
-
-#_(f 1 (partial println "respond")  (partial println "raise"))
-#_(clojure.walk/macroexpand-all  '(defn wrap-auth [handler] (n->multi [request] (handler request))))
-#_(clojure.pprint/pprint (macroexpand-1  '(fnhandler [request] (+ 1 request))))

--- a/src/buddy/auth/middleware.clj
+++ b/src/buddy/auth/middleware.clj
@@ -16,7 +16,8 @@
   (:require [buddy.auth.protocols :as proto]
             [buddy.auth.accessrules :as accessrules]
             [buddy.auth.http :as http]
-            [buddy.auth :refer [authenticated? throw-unauthorized]]))
+            [buddy.auth :refer [authenticated? throw-unauthorized]]
+            [buddy.auth.fnutils :refer [fn->multi]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Authentication
@@ -55,7 +56,7 @@
   handler. When multiple `backends` are given each of them gets a
   chance to authenticate the request."
   [handler & backends]
-  (fn [request]
+  (fn->multi [request]
     (handler (apply authentication-request request backends))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -106,7 +107,7 @@
   hashmap, or an instance that satisfies IAuthorization
   protocol."
   [handler backend]
-  (fn [request]
+  (fn->multi [request]
     (try (handler request)
          (catch Exception e
            (authorization-error request e backend)))))

--- a/test/buddy/auth/fnutils_tests.clj
+++ b/test/buddy/auth/fnutils_tests.clj
@@ -1,0 +1,22 @@
+(ns buddy.auth.fnutils-tests
+  (:require [clojure.test :refer :all]           
+            [buddy.auth.fnutils :refer [fn->multi]]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Arity macro testing
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+(deftest arity-dispatching
+  (testing "Calling arity-1"
+    (let [handler (fn->multi [request] request)]
+      (is (= :ok (handler :ok)))))
+
+  (testing "Calling arity-3"
+    (let [handler (fn->multi [request] request)]
+      (is (= :ok (handler :ok identity identity)))))
+
+  (testing "Calling arity-3 with exception"
+    (let [handler (fn->multi [request] (throw (Exception. "error")))]
+      (is (thrown? Exception 
+                   (handler :ok identity #(throw %)))))))


### PR DESCRIPTION
Ring handlers can be [asynchronous](https://github.com/ring-clojure/ring/wiki/Concepts#handlers). This PR introduces a macro `fn->multi` that is meant to be a replacement of anonymous function declarations `(fn [handler])` to support arity-1 and arity-3 handler functions for sync and async middlewares.

Support is done through a macro - it was my first real world usage of a macro. An alternative would be a higher order function, but I guess it would introduce a slightly higher overhead.