### PR TITLE
Set version 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script:
   - lein test
 
 jdk:
+  - openjdk11
+  - openjdk8
+  - oraclejdk11
   - oraclejdk8
-  - openjdk7
-  - oraclejdk7
-  - oraclejdk9

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Version 3.0.0
+
+Date: 2019-01-02
+
+- Update Clojure to 1.10.0 (and removing java 1.7 as a result)
+- Update buddy-sign to 3.0.0 (breaking change due to new ECDSA signing algo)
+- Support for arity 3 ring middleware functions
+- Updated and expanded tests
+
 ## Version 2.1.0
 
 Date: 2017-08-29

--- a/profiles.clj
+++ b/profiles.clj
@@ -1,13 +1,15 @@
 {:dev
- {:aliases {"test-all" ["with-profile" "dev,1.7:dev,1.8:dev" "test"]}
+ {:aliases {"test-all" ["with-profile" "dev,1.7:dev,1.8:dev,1.9:dev,1.10:dev" "test"]}
   :codeina {:sources ["src"]
             :reader :clojure
             :target "doc/dist/latest/api"
             :src-uri "http://github.com/funcool/buddy-auth/blob/master/"
             :src-uri-prefix "#L"}
   :plugins [[funcool/codeina "0.5.0"]
-            [lein-ancient "0.6.10"]]}
+            [lein-ancient "0.6.15"]]}
 
+ :1.10 {:dependencies [[org.clojure/clojure "1.10.0"]]}
+ :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
  :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
  :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
 

--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,13 @@
-(defproject buddy/buddy-auth "2.1.0"
+(defproject buddy/buddy-auth "3.0.0"
   :description "Authentication and Authorization facilities for ring based web applications."
   :url "https://github.com/funcool/buddy-auth"
   :license {:name "Apache 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha19" :scope "provided"]
-                 [buddy/buddy-sign "2.2.0"]
-                 [funcool/cuerdas "2.0.3"]
-                 [clout "2.1.2"]]
+  :dependencies [[org.clojure/clojure "1.10.0" :scope "provided"]
+                 [buddy/buddy-sign "3.0.0"]
+                 [funcool/cuerdas "2.0.6"]
+                 [clout "2.2.1"]]
   :source-paths ["src"]
   :test-paths ["test"]
   :jar-exclusions [#"\.cljx|\.swp|\.swo|user.clj"]
-  :javac-options ["-target" "1.7" "-source" "1.7" "-Xlint:-options"])
+  :javac-options ["-target" "1.8" "-source" "1.8" "-Xlint:-options"])


### PR DESCRIPTION
I am humbly proposing an upgrade to allow use of the recent features in production without local maven repos.

- Update Clojure to 1.10.0 (and removing java 1.7 as a result)
- Update buddy-sign to 3.0.0 (breaking change due to new ECDSA signing algo)
- Support for arity 3 ring middleware functions
- Updated and expanded tests

As Clojure 1.10.0 is java 8 above only, also bumping travis to
focus on the same targets as Clojure, java 8 and 11