### PR TITLE
Remove Dependency on Funcool Cuerdas

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,6 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.10.1" :scope "provided"]
                  [buddy/buddy-sign "3.1.0"]
-                 [funcool/cuerdas "2.2.0"]
                  [clout "2.2.1"]]
   :source-paths ["src"]
   :test-paths ["test"]

--- a/src/buddy/auth/backends/httpbasic.clj
+++ b/src/buddy/auth/backends/httpbasic.clj
@@ -19,7 +19,7 @@
             [buddy.auth :refer [authenticated?]]
             [buddy.core.codecs :as codecs]
             [buddy.core.codecs.base64 :as b64]
-            [cuerdas.core :as str]))
+            [clojure.string :as str]))
 
 (defn- parse-header
   "Given a request, try to extract and parse
@@ -31,7 +31,7 @@
                          (second)
                          (b64/decode)
                          (codecs/bytes->str))]
-    (when-let [[username password] (str/split decoded #":" 2)]
+    (when-let [[username password] (some-> decoded (str/split #":" 2))]
       {:username username
        :password password})))
 


### PR DESCRIPTION
The only point where Funcool Cuerdas is used is in the HTTP Basic backend. There
it splits the username/password pair. Almost the same function is available in
clojure.string. The only difference is that clojure.string/split can't be called
with a nil first argument. cuerdas.core/split even calls clojure.string/split on
non-nil first argument.